### PR TITLE
Feature/make auth first time optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The project is built with php v8.1.4 and is not complete. Only the endpoints I n
 
 Feel free to fork this project and [contribute](#Contributing) your work to improve the project.
 
+### Supported endpoints
+
+- Orders
+- Returns
+- Subscriptions
+
 ## Getting Started
 
 ### Installation
@@ -34,7 +40,7 @@ Create a new instance of the `Client`
 
 ```php
 $client = new Client(
-    bolClientId: '<client-id',
+    bolClientId: '<client-id>',
     bolClientSecret: '<client-secret>'
 );
 ```

--- a/src/Client.php
+++ b/src/Client.php
@@ -12,6 +12,7 @@ use JeffreyKroonen\BolRetailer\Utilities\Auth;
 
 class Client implements ClientInterface
 {
+    private bool $initialAuthentication = true;
     private Auth $auth;
 
     /**
@@ -39,7 +40,11 @@ class Client implements ClientInterface
      */
     public function setAuth(Auth $auth): self
     {
-        $this->auth = $auth->authenticate();
+        $this->auth = $auth;
+
+        if ($this->initialAuthentication) {
+            $this->auth->authenticate();
+        }
 
         return $this;
     }
@@ -73,6 +78,19 @@ class Client implements ClientInterface
     public function authenticate(): self
     {
         $this->auth->authenticate();
+
+        return $this;
+    }
+
+    /**
+     * Disable calling the method Auth::authentication() when calling Client::setAuth()
+     *
+     * @deprecated Will be removed in the future when we don't authenticate on initialization.
+     * @return self
+     */
+    public function disableInitialAuthentication(): self
+    {
+        $this->initialAuthentication = false;
 
         return $this;
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -96,4 +96,20 @@ final class ClientTest extends TestCase implements MockInterface
         // Then
         $this->assertInstanceOf(Auth::class, $client->getAuth());
     }
+
+    public function testItShouldBePossibleToDisableAuthenticationOnInitializationOfAuthProperty(): void
+    {
+        // Given
+        $mockAuthHandler = $this->mockAuthSuccessResponseHandler();
+        $auth = new Auth(self::MOCK_CLIENT_ID, self::MOCK_CLIENT_SECRET);
+        $auth->getHttp()->setHttpClient(new HttpClient(['handler' => HandlerStack::create($mockAuthHandler)]));
+
+        // When
+        $client = new Client();
+        $client->disableInitialAuthentication();
+        $client->setAuth(auth: $auth);
+
+        // Then
+        $this->assertInstanceOf(Auth::class, $client->getAuth());
+    }
 }


### PR DESCRIPTION
Disable authentication on initializing `Client`

```php
$client = new Client();
$client->disableInitialAuthentication();
$client->setAuth|(new Auth(
  bolClientId: '<client-id>',
  bolClientSecret: '<client-secret>'
));
```

This way the client is testable without making a real HTTP request to Bol.com.

⚠️ This is just a temporary fix and already deprecated, so that it easily can be removed in the future.
⚠️ Authentication on initialization will be removed in the future and **must** be called as method.