### PR TITLE
Give the parameter `$auth` in the constructor the default value of null

### DIFF
--- a/src/Endpoints/BaseEndpoint.php
+++ b/src/Endpoints/BaseEndpoint.php
@@ -44,9 +44,9 @@ abstract class BaseEndpoint
      */
     protected string $credentials;
 
-    public function __construct(?Auth $auth)
+    public function __construct(?Auth $auth = null)
     {
-        if (isset($auth)) {
+        if ($auth) {
             $this->setAuth($auth);
 
             if (! isset($this->http)) {


### PR DESCRIPTION
- Removed the `isset()` check and only check the variable